### PR TITLE
Removed sensio/framework-extra-bundle

### DIFF
--- a/Resources/doc/integrations/easyadmin/ScheduledCommandCrudController.php
+++ b/Resources/doc/integrations/easyadmin/ScheduledCommandCrudController.php
@@ -16,12 +16,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @link https://symfony.com/doc/current/bundles/EasyAdminBundle/actions.html
  * @link https://github.com/Dukecity/CommandSchedulerBundle/wiki/Integrations
- * @Security("is_granted('ROLE_ADMIN')")
+ * #[IsGranted('ROLE_ADMIN')]
  */
 class ScheduledCommandCrudController extends AbstractCrudController
 {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "nesbot/carbon": "^2.53",
         "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/lock": "^5.4 || ^6.0",
-        "sensio/framework-extra-bundle": "^6.2",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/property-access": "^5.4 || ^6.0",


### PR DESCRIPTION
Removing sensio/framework-extra-bundle as the bundle is abandoned, replacing it with native PHP attributes (in resources/docs...).
Can't really test this as I don't use easyadmin, but should be pretty straightforward.
(seemed strange that this was a requirement in the first place as sensio/framework-extra-bundle is not used by the CommandSchedulerBundle itself)