### PR TITLE
fix: spelling of NotifierInterface

### DIFF
--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -159,7 +159,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('controller.service_arguments');
 
 
-    if(class_exists(Symfony\Component\Notifier\NotifierInterface::class))
+    if(class_exists(\Symfony\Component\Notifier\NotifierInterface::class))
     {$notifier = service('notifier');}
     else { $notifier = null; }
 


### PR DESCRIPTION
Fix part of https://github.com/Dukecity/CommandSchedulerBundle/issues/51