### PR TITLE
Fix: Name validation error while trying to save an edited command

### DIFF
--- a/Controller/DetailController.php
+++ b/Controller/DetailController.php
@@ -19,12 +19,16 @@ class DetailController extends AbstractBaseController
      */
     public function edit(Request $request, $id = null): Response
     {
+        $validationGroups = [];
         $scheduledCommand = $id ? $this->getDoctrineManager()->getRepository(ScheduledCommand::class)->find($id) : null;
         if (!$scheduledCommand) {
             $scheduledCommand = new ScheduledCommand();
+            $validationGroups[] = 'new';
         }
 
-        $form = $this->createForm(ScheduledCommandType::class, $scheduledCommand);
+        $form = $this->createForm(ScheduledCommandType::class, $scheduledCommand, [
+            'validation_groups' => $validationGroups
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -18,7 +18,7 @@ use Dukecity\CommandSchedulerBundle\Validator\Constraints as AssertDukecity;
  */
 #[ORM\Entity(repositoryClass: ScheduledCommandRepository::class)]
 #[ORM\Table(name: "scheduled_command")]
-#[UniqueEntity(fields: ["name"])]
+#[UniqueEntity(fields: ["name"], groups: ['new'])]
 class ScheduledCommand
 {
     #[ORM\Id, ORM\Column(type: Types::INTEGER), ORM\GeneratedValue(strategy: 'AUTO')]

--- a/Form/Type/ScheduledCommandType.php
+++ b/Form/Type/ScheduledCommandType.php
@@ -9,6 +9,8 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -20,14 +22,23 @@ class ScheduledCommandType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add(
-            'name',
-            TextType::class,
-            [
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+            /** @var ScheduledCommand $scheduledCommand */
+            $scheduledCommand = $event->getData();
+            $form = $event->getForm();
+            $options = [
                 'label' => 'detail.name',
                 'required' => true,
-            ]
-        );
+            ];
+
+            if (! is_null($scheduledCommand->getId())) {
+                $options['attr'] = ['readonly' => 'readonly'];
+            }
+
+            $form->add('name',
+                TextType::class,
+                $options);
+        });
 
         $builder->add(
             'command',

--- a/Resources/translations/DukecityCommandScheduler.de.xlf
+++ b/Resources/translations/DukecityCommandScheduler.de.xlf
@@ -139,7 +139,7 @@
             </trans-unit>
             <trans-unit id="302">
                 <source>flash.execute</source>
-                <target>Aufgabe "%name%" wird beim nächsten "scheduler:execute" ausgeführt.</target>
+                <target>Aufgabe -%{name}- wird beim nächsten "scheduler:execute" ausgeführt.</target>
             </trans-unit>
             <trans-unit id="303">
                 <source>flash.unlocked</source>

--- a/Resources/translations/DukecityCommandScheduler.de.xlf
+++ b/Resources/translations/DukecityCommandScheduler.de.xlf
@@ -139,7 +139,7 @@
             </trans-unit>
             <trans-unit id="302">
                 <source>flash.execute</source>
-                <target>Aufgabe -%{name}- wird beim nächsten "scheduler:execute" ausgeführt.</target>
+                <target>Aufgabe "%name%" wird beim nächsten "scheduler:execute" ausgeführt.</target>
             </trans-unit>
             <trans-unit id="303">
                 <source>flash.unlocked</source>


### PR DESCRIPTION
Fix: While trying to save an edited command from the command list (command-scheduler/list) an validation error occurs because a command with the same already exists.

The cause of this Problem is the "UniqueEntity" annotation found in the "ScheduledCommand" entity. Its irrelevant whether a new scheduled command is created or an existing one is edited.
This issue is fixed by using a validation group. The "UniqueEntity" constraint now has the validation group "new". This group is added to the form for creating a command, but not to the form to edit an existing command.

To reproduce the fixed problem you have to edit a command in the command list on "/command-scheduler/list". Change something other then the name and try to save the change. It will not work and a note will appear near the name field on the form that will say something like "the name already exists".  To work around that issue you have to change the name every time you want to edit a command, even if only to change the cron expression, for example.
The cause of this Problem is the symfony constraint "UniqueEntity". Even if a form is edited (the record shall only be changed) it will see that a command with the same name already exists in the _scheduled_command_ table. The fix will enable the "UniqueEntity" constraint only for a form to create a new command, but not if an existing command is edited.