### PR TITLE
Fix: NullOutput clear #72

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -191,8 +191,7 @@ HELP
 
             $progress->finish();
 
-
-            if(!is_a($this->output, StreamOutput::class))
+            if(method_exists($sectionProgressbar, 'clear'))
             {$sectionProgressbar->clear();}
 
             $io->section('Finished Executions');


### PR DESCRIPTION
Fix:  #72
When starting the command schedule:start without -v the output will be NullOutput which doesn't contain the clear function
**StartSchedulerCommand.php**
```
        if ($input->getOption('blocking')) {
            $output->writeln(sprintf('<info>%s</info>', 'Starting command scheduler in blocking mode. Press CTRL+C to cancel'));
            $this->scheduler($output->isVerbose() ? $output : new NullOutput(), null);

            return Command::SUCCESS;
        }
```

