### PR TITLE
Fix: Fix caching issue in scheduler start

### DIFF
--- a/Command/StartSchedulerCommand.php
+++ b/Command/StartSchedulerCommand.php
@@ -2,6 +2,8 @@
 
 namespace Dukecity\CommandSchedulerBundle\Command;
 
+use Dukecity\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -21,6 +23,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 class StartSchedulerCommand extends Command
 {
     const PID_FILE = '.cron-pid';
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        string $managerName,
+    ) {
+        $this->em = $managerRegistry->getManager($managerName);
+
+        parent::__construct();
+    }
 
     /**
      * {@inheritdoc}
@@ -108,6 +119,7 @@ HELP
             }
 
             $command->run($input, $output);
+            $this->em->clear(ScheduledCommand::class);
         }
     }
 }

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -148,6 +148,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('console.command');
 
     $services->set(StartSchedulerCommand::class)
+        ->args(
+            [
+                service('doctrine'),
+                '%dukecity_command_scheduler.doctrine_manager%',
+            ]
+        )
         ->tag('console.command');
 
     $services->set(StopSchedulerCommand::class)


### PR DESCRIPTION
Fix: #90

This merge request addresses an issue encountered in production mode on Symfony where updates to a command were not being recognized by the Start Scheduler script. The issue was that the object returned by the `findCommandsToExecute()` method in the `ScheduledCommand` repository was being cached by Doctrine, and therefore not reflecting any new updates from the database.

The fix involves calling Doctrine's `clear()` method on the EntityManager after each command execution in the scheduler. This effectively clears Doctrine's cache and forces it to query the database again the next time it needs data, ensuring that any updates to commands are recognized by the scheduler.

Here is the key change:

```php
while (true) {
    // ...
    $command->run($input, $output);
    $this->em->clear(ScheduledCommand::class);
}
```

This change resolves the issue and ensures that the scheduler always has the most up-to-date command data.