### PR TITLE
Fixed: Wrong translations in button and confirmation to disable a command - 5.x

### DIFF
--- a/Resources/translations/DukecityCommandScheduler.de.xlf
+++ b/Resources/translations/DukecityCommandScheduler.de.xlf
@@ -64,6 +64,14 @@
                 <source>action.cancel</source>
                 <target>Stornieren</target>
             </trans-unit>
+            <trans-unit id="111">
+                <source>confirm.disable</source>
+                <target>Die Aufgabe könnte gerade ausgeführt werden. Möchtest du sie wirklich deaktivieren?</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>action.disable</source>
+                <target>Aufgabe deaktivieren</target>
+            </trans-unit>
 
             <!-- Detail  -->
             <trans-unit id="201">

--- a/Resources/translations/DukecityCommandScheduler.en.xlf
+++ b/Resources/translations/DukecityCommandScheduler.en.xlf
@@ -64,6 +64,14 @@
                 <source>action.cancel</source>
                 <target>Cancel</target>
             </trans-unit>
+            <trans-unit id="111">
+                <source>confirm.disable</source>
+                <target>The task may be running. Are you sure you want to disable it ?</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>action.disable</source>
+                <target>Disable task</target>
+            </trans-unit>
 
             <!-- Detail  -->
             <trans-unit id="201">

--- a/Resources/views/List/index.html.twig
+++ b/Resources/views/List/index.html.twig
@@ -29,7 +29,7 @@
             <tr {% if command.disabled == true %}class="text-muted" {% endif %}>
                 <td {% if command.disabled == false %}data-search="active" data-order="0"{% else %}data-search="deactive" data-order="1"{% endif %}>
                     <a href="{{ path('dukecity_command_scheduler_action_toggle', {'id': command.id}) }}"
-                       data-toggle="confirmation" data-btn-ok-label="{{ "action.unlock"|trans }}" data-title="{{ "confirm.unlock"|trans }}">
+                       data-toggle="confirmation" data-btn-ok-label="{{ "action.disable"|trans }}" data-title="{{ "confirm.disable"|trans }}">
                     {% if command.disabled == true %}
                         <i class="bi bi-power text-danger" title="Activate command"></i>
                     {% else %}


### PR DESCRIPTION
While tapping on the "disable"-icon in the scheduled command list the button label and the confirmation contain text for the unlocking a command.
To fix this two new German and Englisch translations where added and the translation labels where changed from "action.unlock" to "action.disable" and from "confirmation.unlock" to "confirmation.disable".