### PR TITLE
German translation for the immediately started task - 5.x

### DIFF
--- a/Resources/translations/DukecityCommandScheduler.de.xlf
+++ b/Resources/translations/DukecityCommandScheduler.de.xlf
@@ -139,7 +139,7 @@
             </trans-unit>
             <trans-unit id="302">
                 <source>flash.execute</source>
-                <target>Aufgabe -%{name}- wird beim nächsten "scheduler:execute" ausgeführt.</target>
+                <target>Aufgabe "%name%" wird beim nächsten "scheduler:execute" ausgeführt.</target>
             </trans-unit>
             <trans-unit id="303">
                 <source>flash.unlocked</source>


### PR DESCRIPTION
If a task is started immediately a flash message is displayed in the view of the list of commands. But because a wrong placeholder is used in the German translation the placeholder is shown instead the command name.